### PR TITLE
Allow .insertAdjacentHTML() with TrustedHTML

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -47,6 +47,7 @@
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.9",
+    "@types/trusted-types": "^2.0.7",
     "@typescript-eslint/rule-tester": "^8.0.0",
     "chai": "^5.1.1",
     "glob": "^11.0.1",

--- a/packages/eslint-plugin/src/vendors/tsec/common/rules/dom_security/ban_element_insertadjacenthtml.ts
+++ b/packages/eslint-plugin/src/vendors/tsec/common/rules/dom_security/ban_element_insertadjacenthtml.ts
@@ -12,35 +12,98 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  ConformancePatternRule,
-  ErrorCode,
-  PatternKind,
-} from '../../third_party/tsetse/rules/conformance_pattern_rule';
-import {overridePatternConfig} from '../../third_party/tsetse/util/pattern_config';
+import {Allowlist} from '../../third_party/tsetse/allowlist';
+import {Checker} from '../../third_party/tsetse/checker';
+import {ErrorCode} from '../../third_party/tsetse/error_code';
+import {AbstractRule} from '../../third_party/tsetse/rule';
+import {shouldExamineNode} from '../../third_party/tsetse/util/ast_tools';
+import {isExpressionOfAllowedTrustedType} from '../../third_party/tsetse/util/is_trusted_type';
+import {PropertyMatcher} from '../../third_party/tsetse/util/property_matcher';
 import {TRUSTED_HTML} from '../../third_party/tsetse/util/trusted_types_configuration';
+import * as ts from 'typescript';
 
 import {RuleConfiguration} from '../../rule_configuration';
+
+const BANNED_PROPERTY = 'Element.prototype.insertAdjacentHTML';
 
 let errMsg = 'Do not use Element#insertAdjacentHTML, as this can lead to XSS.';
 
 /**
- * A Rule that looks for use of Element#insertAdjacentHTML properties.
+ * Checks if insertAdjacentHTML is called with a TrustedHTML value.
+ * The second argument (index 1) must be TrustedHTML.
  */
-export class Rule extends ConformancePatternRule {
+function isCalledWithTrustedHTML(n: ts.Node, tc: ts.TypeChecker): boolean {
+  const par = n.parent;
+  // Check if this is a call expression
+  if (!ts.isCallExpression(par) || par.expression !== n) return false;
+  // insertAdjacentHTML needs at least 2 arguments
+  if (par.arguments.length < 2) return false;
+
+  // Check if the second argument (the HTML string) is TrustedHTML
+  return isExpressionOfAllowedTrustedType(tc, par.arguments[1], TRUSTED_HTML);
+}
+
+function checkNode(
+  tc: ts.TypeChecker,
+  n: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  matcher: PropertyMatcher,
+): ts.Node | undefined {
+  if (!shouldExamineNode(n)) return;
+  if (!matcher.typeMatches(tc.getTypeAtLocation(n.expression))) return;
+  if (isCalledWithTrustedHTML(n, tc)) return;
+  return n;
+}
+
+/**
+ * A Rule that looks for use of Element#insertAdjacentHTML method.
+ */
+export class Rule extends AbstractRule {
   static readonly RULE_NAME = 'ban-element-insertadjacenthtml';
+  readonly ruleName = Rule.RULE_NAME;
+  readonly code = ErrorCode.CONFORMANCE_PATTERN;
+
+  private readonly propMatcher: PropertyMatcher;
+  private readonly allowlist?: Allowlist;
 
   constructor(configuration: RuleConfiguration = {}) {
-    super(
-      overridePatternConfig({
-        errorCode: ErrorCode.CONFORMANCE_PATTERN,
-        errorMessage: errMsg,
-        kind: PatternKind.BANNED_PROPERTY,
-        values: ['Element.prototype.insertAdjacentHTML'],
-        name: Rule.RULE_NAME,
-        allowedTrustedType: TRUSTED_HTML,
-        ...configuration,
-      }),
+    super();
+    this.propMatcher = PropertyMatcher.fromSpec(BANNED_PROPERTY);
+    if (configuration?.allowlistEntries) {
+      this.allowlist = new Allowlist(configuration?.allowlistEntries);
+    }
+  }
+
+  register(checker: Checker) {
+    checker.onNamedPropertyAccess(
+      this.propMatcher.bannedProperty,
+      (c, n) => {
+        const node = checkNode(c.typeChecker, n, this.propMatcher);
+        if (node) {
+          checker.addFailureAtNode(
+            node,
+            errMsg,
+            Rule.RULE_NAME,
+            this.allowlist,
+          );
+        }
+      },
+      this.code,
+    );
+
+    checker.onStringLiteralElementAccess(
+      this.propMatcher.bannedProperty,
+      (c, n) => {
+        const node = checkNode(c.typeChecker, n, this.propMatcher);
+        if (node) {
+          checker.addFailureAtNode(
+            node,
+            errMsg,
+            Rule.RULE_NAME,
+            this.allowlist,
+          );
+        }
+      },
+      this.code,
     );
   }
 }

--- a/packages/eslint-plugin/test/test.ts
+++ b/packages/eslint-plugin/test/test.ts
@@ -31,13 +31,64 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('trusted-types-checks', trustedTypesChecks, {
-  valid: ['const x = 1;'],
+  valid: [
+    'const x = 1;',
+    // insertAdjacentHTML with TrustedHTML should be allowed
+    `
+      declare const policy: TrustedTypePolicy;
+      const el = document.createElement('div');
+      el.insertAdjacentHTML('beforeend', policy.createHTML('<span>safe</span>'));
+    `,
+    // Using a variable typed as TrustedHTML
+    `
+      declare const trustedHtml: TrustedHTML;
+      const el = document.createElement('div');
+      el.insertAdjacentHTML('afterbegin', trustedHtml);
+    `,
+  ],
   invalid: [
     {
       code: `document.createElement('script').innerHTML = 'foo';`,
       errors: [
         {
           messageId: 'ban_element_innerhtml_assignments',
+        },
+      ],
+    },
+    // insertAdjacentHTML with string should be blocked
+    {
+      code: `
+        const el = document.createElement('div');
+        el.insertAdjacentHTML('beforeend', '<span>unsafe</span>');
+      `,
+      errors: [
+        {
+          messageId: 'ban_element_insertadjacenthtml',
+        },
+      ],
+    },
+    // insertAdjacentHTML with string variable should be blocked
+    {
+      code: `
+        const el = document.createElement('div');
+        const html = '<span>unsafe</span>';
+        el.insertAdjacentHTML('beforeend', html);
+      `,
+      errors: [
+        {
+          messageId: 'ban_element_insertadjacenthtml',
+        },
+      ],
+    },
+    // insertAdjacentHTML accessed via bracket notation
+    {
+      code: `
+        const el = document.createElement('div');
+        el['insertAdjacentHTML']('beforeend', '<span>unsafe</span>');
+      `,
+      errors: [
+        {
+          messageId: 'ban_element_insertadjacenthtml',
         },
       ],
     },

--- a/packages/eslint-plugin/test/test_fixtures/tsconfig.json
+++ b/packages/eslint-plugin/test/test_fixtures/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["trusted-types"]
   },
   "include": ["file.ts", "react.tsx"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,6 +524,7 @@ __metadata:
     "@types/glob": "npm:^8.1.0"
     "@types/mocha": "npm:^10.0.7"
     "@types/node": "npm:^20.14.9"
+    "@types/trusted-types": "npm:^2.0.7"
     "@typescript-eslint/parser": "npm:^8.0.0"
     "@typescript-eslint/rule-tester": "npm:^8.0.0"
     "@typescript-eslint/utils": "npm:^8.0.0"
@@ -752,6 +753,13 @@ __metadata:
   version: 1.3.5
   resolution: "@types/triple-beam@npm:1.3.5"
   checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`.insertAdjacentHTML()` with the 2nd param being TrustedHTML should be allowed, since .innerHTML is allowed too

Add check, inspired by the existing setTimeout check, and add tests